### PR TITLE
Creates a development branch where the unstable release should be accessed from

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Author
 Installation
 ------------
 
-The __MarkDoc__ releases are also hosted on SSC server. So you can download the latest release as follows:
+The older releases of __MarkDoc__ are also hosted on SSC server. So you can download the latest release as follows:
 
-    ssc install markdoc
+    net inst markdoc, from("https://raw.githubusercontent.com/haghish/MarkDoc/master/") rep force
     
 You can also directly download __MarkDoc__ from GitHub which includes the latest beta version (unreleased). The `force` 
 option ensures that you _reinstall_ the package, even if the release date is not yet changed, and thus, must be specified. 
   
-    net install markdoc, force  from("https://raw.githubusercontent.com/haghish/markdoc/master/")
+    net install markdoc, force  from("https://raw.githubusercontent.com/haghish/markdoc/dev/")
     
 __MarkDoc__ also requires two additional Stata packages which are __`weaver`__ and __`statax`__, both hosted on SSC.
 


### PR DESCRIPTION
Instead of directing users to install from the `master` branch for unstable releases, the README is updated to direct users to the dev branch for alpha/beta releases and points them to the master branch for stable releases.
