### PR TITLE
Fixes README for master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Author
 Installation
 ------------
 
-The __MarkDoc__ releases are also hosted on SSC server. So you can download the latest release as follows:
+The older releases of __MarkDoc__ are also hosted on SSC server. So you can download the latest release as follows:
 
-    ssc install markdoc
+    net inst markdoc, from("https://raw.githubusercontent.com/haghish/MarkDoc/master/") rep force
     
 You can also directly download __MarkDoc__ from GitHub which includes the latest beta version (unreleased). The `force` 
 option ensures that you _reinstall_ the package, even if the release date is not yet changed, and thus, must be specified. 
   
-    net install markdoc, force  from("https://raw.githubusercontent.com/haghish/markdoc/master/")
+    net install markdoc, force  from("https://raw.githubusercontent.com/haghish/markdoc/dev/")
     
 __MarkDoc__ also requires two additional Stata packages which are __`weaver`__ and __`statax`__, both hosted on SSC.
 


### PR DESCRIPTION
README stated that current version was available from SSC, but in response to Issue #3, @haghish mentioned that the most current version could be obtained directly from github.  This pull is intended for the master branch to direct users appropriately based on the information in the issue.